### PR TITLE
Updating to handle empty descriptions

### DIFF
--- a/src/podcastsponsorblock/views/youtuberssview.py
+++ b/src/podcastsponsorblock/views/youtuberssview.py
@@ -132,7 +132,7 @@ def populate_feed_generator(
             podcast_feed_generator.itunes_category(escape_for_xml(podcast_config.itunes_category))
     if podcast_config is not None and podcast_config.description is not None:
         feed_generator.subtitle(escape_for_xml(podcast_config.description))
-    elif playlist_details.description is not None:
+    elif playlist_details.description is not None and playlist_details.description:
         feed_generator.subtitle(escape_for_xml(playlist_details.description))
     else:
         feed_generator.subtitle("No description available")


### PR DESCRIPTION
Empty playlist descriptions is causing errors due to a failing check causing the following line to never actually be called:

feed_generator.subtitle("No description available")

2024-04-05 16:49:46   File "/home/appuser/.local/lib/python3.12/site-packages/feedgen/feed.py", line 267, in _create_rss
2024-04-05 16:49:46     raise ValueError('Required fields not set (%s)' % missing)
2024-04-05 16:49:46 ValueError: Required fields not set (description)